### PR TITLE
Dodanie c++11 do CONFIG

### DIFF
--- a/plan.pro
+++ b/plan.pro
@@ -7,6 +7,7 @@ QT += core
   
   TARGET = zapisownik
   CONFIG -= app_bundle
+  CONFIG += c++11
   TEMPLATE = app
   
   SOURCES = src/main.cpp \


### PR DESCRIPTION
Bez tej flagi następuje błąd kompilacji. Przynajmniej na ubuntu 16.04.